### PR TITLE
fix(validate-form): close unterminated quote in hiddenOFF selector [AFV-BUG-0002]

### DIFF
--- a/ValidateForm.js
+++ b/ValidateForm.js
@@ -414,7 +414,7 @@ export class ValidateForm {
       });
     });
     toDeactivate.forEach((toDeactivateEl) => {
-      const inHid = toDeactivateEl.querySelectorAll('input[data-type="hiddenOFF]');
+      const inHid = toDeactivateEl.querySelectorAll('input[data-type="hiddenOFF"]');
       toDeactivateEl.classList.add('isHidden');
       inHid.forEach((inHidEl) => {
         const el = inHidEl;


### PR DESCRIPTION
## Summary
- `ValidateForm.js:417` had `querySelectorAll('input[data-type=\"hiddenOFF]')` — missing closing double-quote
- Threw `SyntaxError: ... is not a valid selector` at runtime, silently breaking the deactivate branch of `_showHidden`

## Test plan
- [x] Fix is a 1-char addition (closing `"`)
- [x] git diff shows only the intended line changed
- [ ] Combined browser smoke test after BUG-0003/4/5 (querySelectorAll returns without throwing)

## Tracking
- Planning Game: AFV-BUG-0002
- Epic: AFV-PCS-0001 [MANTENIMIENTO]