### PR TITLE
fix(validate-form): correct scrollTo coordinates on first warning [AFV-BUG-0003]

### DIFF
--- a/ValidateForm.js
+++ b/ValidateForm.js
@@ -283,7 +283,7 @@ export class ValidateForm {
     if (this.numWarnings === 1) {
       const elementPos = el.getBoundingClientRect();
       const bodyPos = document.body.getBoundingClientRect();
-      window.scrollTo(bodyPos.top, elementPos.top);
+      window.scrollTo(0, elementPos.top - bodyPos.top);
     }
   }
 


### PR DESCRIPTION
## Summary
- `ValidateForm.js:286` called `window.scrollTo(bodyPos.top, elementPos.top)` — passing Y-coordinates to both positional arguments (x, y)
- When there were warnings, the page scrolled to a nonsensical X position instead of the first invalid field
- Fix: `window.scrollTo(0, elementPos.top - bodyPos.top)` → absolute Y of the element on the page

## Rationale
`getBoundingClientRect()` returns **viewport-relative** coordinates. When the page is scrolled, `elementPos.top` is less than the real absolute Y by exactly `bodyPos.top` (which is negative). Subtracting recovers the absolute scroll target without relying on `window.scrollY`.

## Test plan
- [x] 1-line diff, verified with git diff
- [ ] Browser smoke: submit a form with an error in a field below the fold; confirm page scrolls to that field

## Tracking
- Planning Game: AFV-BUG-0003
- Epic: AFV-PCS-0001 [MANTENIMIENTO]