### PR TITLE
fix(verify-utils): T-NIE always returned -3 due to string===boolean [AFV-BUG-0004]

### DIFF
--- a/VerifyUtils.js
+++ b/VerifyUtils.js
@@ -247,11 +247,10 @@ export class VerifyUtils {
         return -2;
       }
       // comprobacion de NIEs
-      // T
-      if (/^[T]{1}[A-Z0-9]{8}$/.test(temp)) {
-        if (a.charAt(8) === /^[T]{1}[A-Z0-9]{8}$/.test(temp)) { return 3; }
-        return -3;
-      }
+      // T: formato historico (T + 8 alfanumericos). No tiene algoritmo oficial
+      // de digito de control, asi que validamos unicamente el formato — si el
+      // outer regex del inicio dejo pasar este valor, el formato es valido.
+      if (/^[T]{1}[A-Z0-9]{8}$/.test(temp)) { return 3; }
       // XYZ
       if (/^[XYZ]{1}/.test(temp)) {
         temp = temp.replace('X', '0');


### PR DESCRIPTION
## Summary
- `VerifyUtils.js:252` compared `a.charAt(8)` (string) against `/^[T]{1}[A-Z0-9]{8}$/.test(temp)` (boolean). Strict-equality across types is always `false`, so every T-NIE returned `-3` (invalid)
- T-NIEs (historic temporary foreign resident ID) have no standardised check-digit algorithm — the outer format regex already guarantees validity
- Fix: return `3` when the outer regex matches; drop the dead inner comparison

## Test plan
- [x] git diff shows only the T-NIE branch touched
- [ ] Regression test in the upcoming Vitest suite (AFV-TSK-0004) asserts `validaNifCifNie('T12345678') === 3`
- [ ] Same suite asserts that format-invalid T inputs are still rejected upstream

## Tracking
- Planning Game: AFV-BUG-0004
- Epic: AFV-PCS-0001 [MANTENIMIENTO]