### PR TITLE
fix(verify-utils): CIF numeric control digit comparison [AFV-BUG-0005]

### DIFF
--- a/VerifyUtils.js
+++ b/VerifyUtils.js
@@ -239,9 +239,9 @@ export class VerifyUtils {
       }
       // comprobacion de CIFs
       if (/^[ABCDEFGHJNPQRSUVW]{1}/.test(temp)) {
-        temp = `${n}`;
-        if (a.charAt(8) === String.fromCharCode(64 + n)
-            || a.charAt(8) === parseInt(temp.substring(temp.length - 1, temp.length), 10)) {
+        const controlLetter = String.fromCharCode(64 + n);
+        const controlDigit = String(n % 10);
+        if (a.charAt(8) === controlLetter || a.charAt(8) === controlDigit) {
           return 2;
         }
         return -2;


### PR DESCRIPTION
## Summary
- CIF control digit can be either a letter (A–J) or a digit (0–9)
- `VerifyUtils.js:244` compared `a.charAt(8)` (string) against `parseInt(...)` (number) with `===`. Always false → valid CIFs with numeric control digits were rejected
- Fix: normalise both alternatives to strings (`String.fromCharCode(64+n)` and `String(n%10)`) and compare as strings

## Also removes
- Dead `temp = \`\${n}\`` reassignment that wasn't read afterwards (previously used to derive the digit via `.substring`)

## Test plan
- [x] git diff limited to the CIF branch
- [ ] Vitest regression (AFV-TSK-0004): 'B82846856' (numeric control) → 2, 'A58818501' (letter control) → 2, 'B82846857' (wrong control) → -2

## Tracking
- Planning Game: AFV-BUG-0005
- Epic: AFV-PCS-0001 [MANTENIMIENTO]