### PR TITLE
feat(validate-form)!: replace window[fn] with callback allow-list [AFV-TSK-0001]

### DIFF
--- a/ValidateForm.js
+++ b/ValidateForm.js
@@ -11,6 +11,7 @@ export class ValidateForm {
     this.cssElementWarning = confOpt.cssElementWarning || `border:2px solid ${this.warningColor}!important;`;
     this.requiredTextContent = confOpt.requiredTextContent || '*';
     this.scope = confOpt.scope || document;
+    this.validationCallbacks = confOpt.validationCallbacks || {};
 
     this.numWarnings = 0;
     this.texts = {
@@ -138,10 +139,14 @@ export class ValidateForm {
     if (val === '' || val === null || (val !== '' && type === 'noempty')) { return true; }
     if (type === 'selected' || type === 'noempty') { return (val !== ''); }
     if (type.substr(0, 3) === 'fn:') {
-      const fn = window[type.substr(3)];
+      const callbackName = type.substr(3);
+      const fn = this.validationCallbacks[callbackName];
       if (typeof fn === 'function') {
         return fn(val);
       }
+      // eslint-disable-next-line no-console
+      console.warn(`[ValidateForm] validation callback "${callbackName}" is not registered in validationCallbacks. Register it via the confOpt.validationCallbacks allow-list.`);
+      return false;
     }
     if (type.substr(0, 5) === 'file:') {
       const validExtensions = type.substr(5).split(',');

--- a/demo/index.html
+++ b/demo/index.html
@@ -255,12 +255,6 @@
       </form>
     </div>
 
-    <script>
-      function checkOdd(value) {
-        return value % 2 == 0;
-      }
-    </script>
-
     <script type="module">
       import { ValidateForm } from "../ValidateForm.js";
 
@@ -269,9 +263,17 @@
         return false;
       }
 
+      function checkOdd(value) {
+        return value % 2 == 0;
+      }
+
       window.onload = function () {
         /** THIS LINE VALIDATE ALL THE FORMS **/
-        const validateForm = new ValidateForm(submitFunction);
+        const validateForm = new ValidateForm(submitFunction, {
+          validationCallbacks: {
+            checkOdd,
+          },
+        });
 
         const addNewField = () => {
           const label = document.createElement("label");

--- a/test/ValidateForm.test.js
+++ b/test/ValidateForm.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { ValidateForm } from '../ValidateForm.js';
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <input id="documento_de_identidad" value="DNI" />
+    <form id="f" data-validate="true">
+      <input id="num" name="num" type="number" data-tovalidate="fn:myEven" />
+      <input id="txt" name="txt" type="text" data-tovalidate="fn:ghost" />
+    </form>
+  `;
+});
+
+describe('ValidateForm.validate callback allow-list (AFV-TSK-0001)', () => {
+  it('invokes a registered validation callback when data-tovalidate starts with fn:', () => {
+    const myEven = vi.fn((v) => Number(v) % 2 === 0);
+    const vf = new ValidateForm(() => true, { validationCallbacks: { myEven } });
+
+    expect(vf.validate('4', 'fn:myEven')).toBe(true);
+    expect(vf.validate('3', 'fn:myEven')).toBe(false);
+    expect(myEven).toHaveBeenCalledWith('4');
+    expect(myEven).toHaveBeenCalledWith('3');
+  });
+
+  it('rejects + warns when the callback is not in the allow-list', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const vf = new ValidateForm(() => true, { validationCallbacks: {} });
+
+    expect(vf.validate('anything', 'fn:ghost')).toBe(false);
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toMatch(/"ghost"/);
+
+    warnSpy.mockRestore();
+  });
+
+  it('does not fall back to window[fn] when a global function with the same name exists', () => {
+    globalThis.unsafeGlobal = vi.fn(() => true);
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const vf = new ValidateForm(() => true);
+
+    expect(vf.validate('x', 'fn:unsafeGlobal')).toBe(false);
+    expect(globalThis.unsafeGlobal).not.toHaveBeenCalled();
+
+    delete globalThis.unsafeGlobal;
+    warnSpy.mockRestore();
+  });
+
+  it('exposes validationCallbacks on the instance (defaults to empty object)', () => {
+    const vf = new ValidateForm(() => true);
+    expect(vf.validationCallbacks).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary (BREAKING CHANGE)
Closes the arbitrary-function-execution vector where `data-tovalidate="fn:whatever"` on any form input could reach into `window[whatever]` and invoke any global function. With this PR:

- `new ValidateForm(submit, { validationCallbacks: { myFn } })` — explicit allow-list
- `data-tovalidate="fn:myFn"` now looks up `this.validationCallbacks.myFn`
- Unregistered callbacks → `false` + `console.warn` naming the missing name
- `window[fn]` is removed from the repo (verified via grep)
- `demo/index.html` migrates `checkOdd` to the allow-list and drops the global

## Migration
**Before**
```html
<script>function checkOdd(v) { return v % 2 === 0; }</script>
<script type="module">
  new ValidateForm(submit); // fn:checkOdd was picked up from window
</script>
```

**After**
```html
<script type="module">
  function checkOdd(v) { return v % 2 === 0; }
  new ValidateForm(submit, { validationCallbacks: { checkOdd } });
</script>
```

## Test plan
- [x] `test/ValidateForm.test.js`: 4 new regression tests
  - registered callback is invoked with the value
  - unregistered callback → `false` + `console.warn` mentioning the name
  - a global function matching the name is NOT reached (no window fallback)
  - `instance.validationCallbacks` defaults to `{}`
- [x] Whole suite: 66 passed

## Tracking
- Planning Game: AFV-TSK-0001
- Epic: AFV-PCS-0001 [MANTENIMIENTO]