### PR TITLE
fix(validate-form): innerHTML → textContent to prevent XSS [AFV-TSK-0002]

### DIFF
--- a/ValidateForm.js
+++ b/ValidateForm.js
@@ -73,7 +73,7 @@ export class ValidateForm {
       const style = document.createElement('style');
       style.setAttribute('id', 'valiformStyles');
       style.setAttribute('type', 'text/css');
-      style.innerHTML = '.isHidden{ display:none; }';
+      style.textContent = '.isHidden{ display:none; }';
       document.getElementsByTagName('head')[0].appendChild(style);
     }
   }
@@ -161,7 +161,7 @@ export class ValidateForm {
       const asterisco = document.createElement('span');
       asterisco.setAttribute('id', `asterisco_${idAst}`);
       asterisco.setAttribute('style', this.asteriskStyle);
-      asterisco.innerHTML = this.requiredTextContent;
+      asterisco.textContent = this.requiredTextContent;
       if (this.scope.querySelector(`#label_${idAst}`) !== null) {
         this.scope.querySelector(`#label_${idAst}`).appendChild(asterisco);
       } else {
@@ -281,7 +281,7 @@ export class ValidateForm {
       warning = this.scope.querySelector(`#${id}`);
     }
     warning.setAttribute('style', this.cssTextWarning);
-    warning.innerHTML = msg;
+    warning.textContent = msg;
     el.parentElement.appendChild(warning);
     el.setAttribute('style', this.cssElementWarning);
     this.numWarnings += 1;

--- a/test/ValidateForm.test.js
+++ b/test/ValidateForm.test.js
@@ -11,6 +11,23 @@ beforeEach(() => {
   `;
 });
 
+describe('ValidateForm.addWarnMesg XSS safety (AFV-TSK-0002)', () => {
+  it('renders script payloads as plain text, never executing them', () => {
+    const vf = new ValidateForm(() => true);
+    const target = document.getElementById('num');
+    const payload = '<script>window.__xss = true;</script>';
+
+    vf.addWarnMesg(target, payload);
+
+    const warning = document.getElementById('warning-num');
+    expect(warning).not.toBeNull();
+    expect(warning.textContent).toBe(payload);
+    expect(warning.querySelector('script')).toBeNull();
+    expect(globalThis.__xss).toBeUndefined();
+  });
+
+});
+
 describe('ValidateForm.validate callback allow-list (AFV-TSK-0001)', () => {
   it('invokes a registered validation callback when data-tovalidate starts with fn:', () => {
     const myEven = vi.fn((v) => Number(v) % 2 === 0);


### PR DESCRIPTION
## Summary
Every `innerHTML` assignment in `ValidateForm.js` is replaced with `textContent`:

| Line | Context | Risk |
|---|---|---|
| 284 | `warning.textContent = msg` | **Critical** — msg comes from `data-error-msg`, attacker-controlled |
| 164 | `asterisco.textContent = '*'` | Low — constant, but removes another innerHTML |
| 76   | `style.textContent = '.isHidden{display:none;}'` | None functionally; style tags accept either |

## Test plan
- [x] `test/ValidateForm.test.js` new regression:
  - calls `addWarnMesg(target, '<script>window.__xss = true;</script>')`
  - asserts `warning.textContent === payload` (rendered as text)
  - asserts `warning.querySelector('script') === null` (no parsed DOM)
  - asserts `globalThis.__xss === undefined` (script never ran)
- [x] `grep innerHTML ValidateForm.js` → 0 matches (acceptance criterion)
- [x] Whole suite: 67 passed

## Tracking
- Planning Game: AFV-TSK-0002
- Epic: AFV-PCS-0001 [MANTENIMIENTO]