### PR TITLE
style(demo): own stylesheet, drop bootstrap CDN, showcase NIF field [AFV-TSK-0005]

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,23 +1,29 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>Demo of ValidateForm Class</title>
-    <link
-      rel="stylesheet"
-      type="text/css"
-      href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css"
-    />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Valiform.js — Complex Example</title>
+    <link rel="stylesheet" href="./styles.css" />
   </head>
   <body>
-    <div id="top-nav" class="navbar navbar-inverse navbar-static-top">
-      <div class="container-fluid">
-        <div class="navbar-header">
-          <h1 style="color: #f93">Valiform.js - Complex Example</h1>
-        </div>
-      </div>
-    </div>
-    <div class="container-fluid">
-      <form id="myForm" data-validate="true" data-checkrealtime="true">
+    <!-- Hidden field read by VerifyUtils.validaNifCifNie. AFV-BUG-0012 tracks
+         removing this hard-coded dependency. For now, demo declares it as DNI. -->
+    <input id="documento_de_identidad" type="hidden" value="DNI" />
+
+    <header class="valiform-header">
+      <h1>Valiform.js — Complex Example</h1>
+      <p>Declarative form validation driven by <code>data-*</code> attributes.</p>
+    </header>
+
+    <main class="valiform-container">
+      <form
+        id="myForm"
+        class="valiform-form"
+        data-validate="true"
+        data-checkrealtime="true"
+        novalidate
+      >
         <div id="field1">
           <div class="form-group">
             <label for="name">Your name</label>
@@ -26,7 +32,7 @@
               id="name"
               name="name"
               type="text"
-              placeholder="type your name"
+              placeholder="Type your name"
               data-required="true"
               data-tovalidate="alfa"
             />
@@ -38,118 +44,87 @@
               class="form-control"
               id="email"
               name="email"
-              type="text"
-              placeholder="type your email"
+              type="email"
+              placeholder="you@example.com"
               data-required="true"
               data-tovalidate="email"
             />
           </div>
 
           <div class="form-group">
-            <label id="label_englishlevel" data-name="englishlevel"
-              >What is your english level?</label
-            >
-            <label for="levelA1">
-              <input
-                id="levelA1"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="A1"
-              />A1
-            </label>
-            <label for="levelA2">
-              <input
-                id="levelA2"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="A2"
-              />A2
-            </label>
-            <label for="levelB1">
-              <input
-                id="levelB1"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="B1"
-              />B1
-            </label>
-            <label for="levelB2">
-              <input
-                id="levelB2"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="B2"
-              />B2
-            </label>
-            <label for="levelC1">
-              <input
-                id="levelC1"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="C1"
-              />C1
-            </label>
-            <label for="levelC2">
-              <input
-                id="levelC2"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="C2"
-              />C2
-            </label>
-            <label for="levelNative">
-              <input
-                id="levelNative"
-                name="englishlevel"
-                type="radio"
-                data-required="true"
-                value="Native"
-              />Native
-            </label>
+            <label for="dni">NIF / NIE</label>
+            <input
+              class="form-control"
+              id="dni"
+              name="dni"
+              type="text"
+              placeholder="12345678Z"
+              data-required="true"
+              data-tovalidate="nif"
+            />
+            <span class="hint">Acepta DNI, NIE (X/Y/Z/T) y CIF.</span>
           </div>
 
           <div class="form-group">
-            <label id="label_hasphone" data-name="hasphone"
-              >Do you have a phone number?</label
-            >
-            <label for="hasphoneNO">
-              <input
-                id="hasphoneNO"
-                name="hasphone"
-                type="radio"
-                data-required="true"
-                value="nophone"
-              />
-              No
+            <label id="label_englishlevel" data-name="englishlevel">
+              What is your English level?
             </label>
-            <label for="hasphoneYES">
-              <input
-                id="hasphoneYES"
-                name="hasphone"
-                type="radio"
-                data-required="true"
-                value="yesphone"
-              />
-              Yes
+            <div class="radio-group">
+              <label for="levelA1">
+                <input id="levelA1" name="englishlevel" type="radio" data-required="true" value="A1" /> A1
+              </label>
+              <label for="levelA2">
+                <input id="levelA2" name="englishlevel" type="radio" data-required="true" value="A2" /> A2
+              </label>
+              <label for="levelB1">
+                <input id="levelB1" name="englishlevel" type="radio" data-required="true" value="B1" /> B1
+              </label>
+              <label for="levelB2">
+                <input id="levelB2" name="englishlevel" type="radio" data-required="true" value="B2" /> B2
+              </label>
+              <label for="levelC1">
+                <input id="levelC1" name="englishlevel" type="radio" data-required="true" value="C1" /> C1
+              </label>
+              <label for="levelC2">
+                <input id="levelC2" name="englishlevel" type="radio" data-required="true" value="C2" /> C2
+              </label>
+              <label for="levelNative">
+                <input id="levelNative" name="englishlevel" type="radio" data-required="true" value="Native" /> Native
+              </label>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label id="label_hasphone" data-name="hasphone">
+              Do you have a phone number?
             </label>
+            <div class="radio-group">
+              <label for="hasphoneNO">
+                <input id="hasphoneNO" name="hasphone" type="radio" data-required="true" value="nophone" />
+                No
+              </label>
+              <label for="hasphoneYES">
+                <input id="hasphoneYES" name="hasphone" type="radio" data-required="true" value="yesphone" />
+                Yes
+              </label>
+            </div>
+
             <fieldset data-activate="hasphoneYES" data-deactivate="hasphoneNO">
-              <label for="phone">Phone number</label>
-              <input
-                id="phone"
-                name="phone"
-                data-type="hiddenON"
-                type="text"
-                data-required="true"
-                data-tovalidate="telephone"
-                placeholder="Your telephone number"
-              />
+              <label for="phone">
+                Phone number
+                <input
+                  class="form-control"
+                  id="phone"
+                  name="phone"
+                  data-type="hiddenON"
+                  type="text"
+                  data-required="true"
+                  data-tovalidate="telephone"
+                  placeholder="+34 666 123 456"
+                />
+              </label>
             </fieldset>
+
             <fieldset data-activate="hasphoneYES" data-deactivate="hasphoneNO">
               <label for="allowcall">
                 <input
@@ -172,40 +147,27 @@
               data-max="4"
               data-min="2"
               data-required="true"
-              data-error-msg="Selecciona entre 2 y 4 peliculas favoritas"
+              data-error-msg="Select between 2 and 4 favourite movies"
             >
-              Select between 2 and 4 movies:
+              Select between 2 and 4 movies
             </label>
-            <label for="movie_1"
-              >Movie 1<input id="movie_1" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_2"
-              >Movie 2<input id="movie_2" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_3"
-              >Movie 3<input id="movie_3" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_4"
-              >Movie 4<input id="movie_4" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_5"
-              >Movie 5<input id="movie_5" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_6"
-              >Movie 6<input id="movie_6" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_7"
-              >Movie 7<input id="movie_7" name="movies" type="checkbox"
-            /></label>
-            <label for="movie_8"
-              >Movie 8<input id="movie_8" name="movies" type="checkbox"
-            /></label>
+            <div class="checkbox-group">
+              <label for="movie_1"><input id="movie_1" name="movies" type="checkbox" /> Movie 1</label>
+              <label for="movie_2"><input id="movie_2" name="movies" type="checkbox" /> Movie 2</label>
+              <label for="movie_3"><input id="movie_3" name="movies" type="checkbox" /> Movie 3</label>
+              <label for="movie_4"><input id="movie_4" name="movies" type="checkbox" /> Movie 4</label>
+              <label for="movie_5"><input id="movie_5" name="movies" type="checkbox" /> Movie 5</label>
+              <label for="movie_6"><input id="movie_6" name="movies" type="checkbox" /> Movie 6</label>
+              <label for="movie_7"><input id="movie_7" name="movies" type="checkbox" /> Movie 7</label>
+              <label for="movie_8"><input id="movie_8" name="movies" type="checkbox" /> Movie 8</label>
+            </div>
           </div>
 
           <div class="form-group">
             <label for="oddvalues">
-              Introduce un valor par mayor que 1 y menos que 9:
+              Even value between 1 and 9
               <input
+                class="form-control"
                 id="oddvalues"
                 name="oddvalues"
                 type="number"
@@ -218,42 +180,32 @@
           </div>
 
           <div class="form-group">
-            <input
-              id="accept"
-              name="accept"
-              type="checkbox"
-              data-required="true"
-            />
-            <span>Accept conditions</span>
+            <label for="accept">
+              <input id="accept" name="accept" type="checkbox" data-required="true" />
+              Accept conditions
+            </label>
           </div>
 
           <div class="form-group">
-            <label for="photoFile"
-              >Sube una foto:
+            <label for="photoFile">
+              Upload a picture
               <input
                 id="photoFile"
                 type="file"
                 name="file"
                 data-required="true"
                 data-tovalidate="file:png,pdf"
-                data-info="Extensions Allowed: png and pdf"
+                data-info="Extensions allowed: png and pdf"
               />
             </label>
           </div>
 
           <div class="button-group">
-            <button
-              id="submitBtn"
-              type="submit"
-              class="btn btn-info"
-              data-checkform="true"
-            >
-              Submit
-            </button>
+            <button id="submitBtn" type="submit" data-checkform="true">Submit</button>
           </div>
         </div>
       </form>
-    </div>
+    </main>
 
     <script type="module">
       import { ValidateForm } from "../ValidateForm.js";
@@ -264,36 +216,16 @@
       }
 
       function checkOdd(value) {
-        return value % 2 == 0;
+        return value % 2 === 0;
       }
 
-      window.onload = function () {
-        /** THIS LINE VALIDATE ALL THE FORMS **/
+      window.addEventListener("load", () => {
+        /** THIS LINE VALIDATES ALL THE FORMS **/
+        // eslint-disable-next-line no-unused-vars
         const validateForm = new ValidateForm(submitFunction, {
-          validationCallbacks: {
-            checkOdd,
-          },
+          validationCallbacks: { checkOdd },
         });
-
-        const addNewField = () => {
-          const label = document.createElement("label");
-          label.innerHTML = "This is a Alpha field added after 1 second: ";
-          label.setAttribute("for", "tardio");
-          const input = document.createElement("input");
-          input.setAttribute("type", "text");
-          input.setAttribute("name", "tardio");
-          input.setAttribute("id", "tardio");
-          input.setAttribute("data-required", "true");
-          input.setAttribute("data-tovalidate", "alpha");
-          input.classList.add("form-control");
-          const div = document.createElement("div");
-          div.setAttribute("class", "form-group");
-          div.appendChild(label);
-          div.appendChild(input);
-          document.getElementById("myForm").appendChild(div);
-          validateForm.checkFieldsToValidate();
-        };
-      };
+      });
     </script>
   </body>
 </html>

--- a/demo/styles.css
+++ b/demo/styles.css
@@ -1,0 +1,241 @@
+:root {
+  color-scheme: light;
+  --bg: #f6f7fb;
+  --surface: #ffffff;
+  --border: #d8dde8;
+  --border-strong: #bcc3d4;
+  --text: #1f2430;
+  --text-muted: #5b6478;
+  --accent: #3b5bfd;
+  --accent-hover: #2a49e6;
+  --accent-ring: rgba(59, 91, 253, 0.18);
+  --danger: #d0342c;
+  --danger-bg: #fdecec;
+  --success: #1d8f4e;
+  --radius: 10px;
+  --radius-sm: 6px;
+  --shadow: 0 10px 30px rgba(24, 32, 60, 0.08);
+  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue",
+          Arial, "Noto Sans", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font);
+  font-size: 16px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.valiform-header {
+  padding: 2rem 1rem 1rem;
+  text-align: center;
+}
+
+.valiform-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.valiform-header p {
+  margin: 0.5rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.valiform-container {
+  max-width: 680px;
+  margin: 1rem auto 3rem;
+  padding: 0 1rem;
+}
+
+form.valiform-form {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 2rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1.25rem;
+}
+
+.form-group > label {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.form-group .hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.form-control {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  color: var(--text);
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.form-control:hover {
+  border-color: var(--border-strong);
+}
+
+.form-control:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-ring);
+}
+
+.radio-group,
+.checkbox-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+}
+
+.radio-group label,
+.checkbox-group label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 400;
+  font-size: 0.9rem;
+  color: var(--text);
+  cursor: pointer;
+  user-select: none;
+}
+
+.radio-group input[type="radio"],
+.checkbox-group input[type="checkbox"] {
+  accent-color: var(--accent);
+}
+
+fieldset {
+  border: 1px dashed var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 0 0;
+}
+
+fieldset > label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+fieldset > label input[type="text"] {
+  margin-top: 0.25rem;
+}
+
+input[type="file"] {
+  padding: 0.4rem;
+  background: #fafbff;
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  width: 100%;
+}
+
+input[type="file"]::file-selector-button {
+  font: inherit;
+  padding: 0.35rem 0.75rem;
+  margin-right: 0.75rem;
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+input[type="file"]::file-selector-button:hover {
+  background: var(--accent-hover);
+}
+
+.button-group {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1.5rem;
+}
+
+button[type="submit"] {
+  appearance: none;
+  font: inherit;
+  font-weight: 600;
+  color: #fff;
+  background: var(--accent);
+  border: 0;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1.5rem;
+  cursor: pointer;
+  transition: background-color 120ms ease, transform 120ms ease;
+}
+
+button[type="submit"]:hover {
+  background: var(--accent-hover);
+}
+
+button[type="submit"]:active {
+  transform: translateY(1px);
+}
+
+/* Validation state — Valiform applies inline border style on error fields and
+   appends a <p id="warning-xxx"> sibling. We scope selectors loosely so the
+   inline styles win (important) while still giving a subtle background. */
+.form-group input[style*="border"],
+.form-group select[style*="border"],
+.form-group textarea[style*="border"] {
+  background: var(--danger-bg);
+}
+
+p[id^="warning-"] {
+  margin: 0.25rem 0 0;
+  padding: 0.4rem 0.6rem;
+  background: var(--danger-bg);
+  border-left: 3px solid var(--danger);
+  border-radius: 3px;
+  font-size: 0.85rem;
+  color: var(--danger) !important;
+}
+
+/* Required-field asterisk injected by Valiform */
+span[id^="asterisco_"] {
+  font-size: 0.95rem !important;
+}
+
+/* Small screens */
+@media (max-width: 560px) {
+  form.valiform-form {
+    padding: 1.25rem;
+    border-radius: 0;
+    border-left: 0;
+    border-right: 0;
+  }
+  .valiform-container {
+    padding: 0;
+  }
+  .radio-group,
+  .checkbox-group {
+    gap: 0.4rem 0.8rem;
+  }
+}


### PR DESCRIPTION
## Summary
- Drops the stale `maxcdn.bootstrapcdn.com` Bootstrap 3 `<link>` — the demo no longer depends on any CDN
- New `demo/styles.css` (~200 LoC): system font stack, centered card, focus ring, error state with rose background + red border + prefixed warning paragraph, mobile breakpoint at 560px
- Adds a `NIF / NIE` field with `data-tovalidate="nif"` so visitors can verify the AFV-BUG-0001 fix end-to-end
- Injects the `documento_de_identidad` stub input required by `validaNifCifNie` (tracked for removal in AFV-BUG-0012)
- `window.onload = …` → `window.addEventListener('load', …)` for ES-module compatibility

## Screenshots
- Clean state: rendered, all inputs visible, NIF hint under the input
- Submit empty → red borders on every required field + `campo requerido` warnings
- Typing `12345678A` → `valor incorrecto` (wrong DNI letter, reaches `validaNifCifNie`)
- Typing `12345678Z` → accepted (regression proof for AFV-BUG-0001)

## Test plan
- [x] `python3 -m http.server` + Chrome DevTools: page loads, no console errors beyond a favicon 404
- [x] Required-field submit path renders the error state
- [x] NIF validator rejects `12345678A` and accepts `12345678Z`
- [x] Vitest suite unaffected (67 passed)

## Tracking
- Planning Game: AFV-TSK-0005
- Epic: AFV-PCS-0001 [MANTENIMIENTO]