### PR TITLE
feat(form-validators): add normalize() per validator + bump to 1.0.0 (AFV-TSK-0007)

### DIFF
--- a/packages/form-validators/README.md
+++ b/packages/form-validators/README.md
@@ -1,8 +1,8 @@
 # @manufosela/form-validators
 
-> **Library.** Pure deterministic predicates for common form-field validation. Zero dependencies, zero DOM access. MIT-licensed.
+> **Library.** Pure deterministic predicates and normalizers for common form-field validation. Zero dependencies, zero DOM access. MIT-licensed.
 
-Each validator is a named export that takes a value and returns a `boolean`. Designed to be the validation core of UI libraries (`automatic_form_validation`, `@manufosela/ai-form`) and of any custom form code.
+Each validator is a named export that takes a value and returns a `boolean`. Each validator also has a paired `normalize<Name>(value)` function that returns the canonical form (trim + format-specific cleanup like stripping country code from phones, lowercasing emails, uppercasing Spanish documents, etc.). Designed to be the validation core of UI libraries (`automatic_form_validation`, `@manufosela/ai-form`) and of any custom form code.
 
 ## Install
 
@@ -21,30 +21,57 @@ nif('12345678Z'); // true (control letter checked)
 creditCard('4111111111111111'); // true (Luhn-checked)
 ```
 
-### Lookup by name
+### Normalizers
 
-For dynamic dispatch (e.g. from a `data-tovalidate` attribute), use `validate(name)`:
+Pair each validator with `normalize<Name>(value)` to get the canonical form before storing:
 
 ```js
-import { validate } from '@manufosela/form-validators';
+import { normalizeMobileEs, normalizeEmail, normalizeNif } from '@manufosela/form-validators';
 
-const fn = validate('movil');
-fn('600 000 000'); // true
+normalizeMobileEs('+34 639 01 89 87'); // '639018987'
+normalizeEmail(' Manu@Example.IO '); // 'manu@example.io'
+normalizeNif(' 12345678z '); // '12345678Z'
 ```
 
-The name lookup is case-insensitive and accepts every alias from the legacy [`automatic_form_validation`](../automatic-form-validation) library: `mobile`, `movil`, `nummovil`, `email`, `correo`, `nif`, `cif`, `nie`, `cuentabancaria`, `creditcard`, `tarjetacredito`, etc.
+Compose `normalize` then `validate` for the typical "clean and check" pipeline:
+
+```js
+import { normalizeMobileEs, mobileEs } from '@manufosela/form-validators';
+const value = normalizeMobileEs(rawInput);
+if (mobileEs(value)) save(value); // store the canonical form
+```
+
+### Lookup by name
+
+For dynamic dispatch (e.g. from a `data-tovalidate` attribute), use `validate(name)` and `normalize(name)`:
+
+```js
+import { validate, normalize } from '@manufosela/form-validators';
+
+const fn = validate('movil');
+const clean = normalize('movil');
+fn(clean('+34 600 000 000')); // → true, value stored as '600000000'
+```
+
+Both lookups are case-insensitive and accept every alias from the legacy [`automatic_form_validation`](../automatic-form-validation) library: `mobile`, `movil`, `nummovil`, `email`, `correo`, `nif`, `cif`, `nie`, `cuentabancaria`, `creditcard`, `tarjetacredito`, etc. `normalize(name)` of an unknown name returns a safe trim-only fallback so callers never need to null-check.
 
 ## Validator catalogue
 
-| Category | Validators |
-| -------- | ---------- |
-| Numeric  | `integer`, `float`, `number` |
-| Text     | `alpha`, `alphaWithDash`, `alphanumeric`, `alphanumericWithSpace` |
-| Date     | `date(value, mode?)` — mode `'dmy'` (default), `'mdy'`, `'ymd'` |
-| File     | `fileExtension(filename, [".pdf", ".doc"])` |
-| Communications | `email`, `url`, `mobileEs`, `landlineEs`, `telephoneEs`, `postalCodeEs`, `iccid` |
-| Spanish documents | `nif`, `nie`, `cif`, `bankAccountEs` (CCC) |
-| Banking | `creditCard` (Luhn) |
+| Category | Validators | Normalizer canonicalises |
+| -------- | ---------- | ------------------------ |
+| Numeric  | `integer`, `float`, `number` | trim + accept comma decimal |
+| Text     | `alpha`, `alphaWithDash`, `alphanumeric`, `alphanumericWithSpace` | trim + collapse internal whitespace |
+| Date     | `date(value, mode?)` — mode `'dmy'` (default), `'mdy'`, `'ymd'` | `dd/mm/yyyy` (or `yyyy/mm/dd`), zero-padded |
+| File     | `fileExtension(filename, [".pdf", ".doc"])` | trim only |
+| Email    | `email` | trim + lowercase + strip whitespace |
+| URL      | `url` | trim + prepend `https://` if missing + lowercase scheme/host |
+| Phones   | `mobileEs`, `landlineEs`, `telephoneEs`, `postalCodeEs`, `iccid` | trim + strip separators + strip `+34`/`0034`/`34` country prefix |
+| Spanish documents | `nif`, `nie`, `cif`, `bankAccountEs` (CCC) | trim + uppercase + strip separators |
+| Banking | `creditCard` (Luhn) | trim + strip spaces/hyphens/dots |
+
+## Versioning
+
+Project policy: **semver from 1.0.0**. There is no 0.x phase — when something is released, it's released. Breaking changes bump major. The first release of this package was `1.0.0` even though the catalogue had been previously available as a sub-module of `automatic_form_validation@1.6.0`.
 
 ## Origin
 

--- a/packages/form-validators/package.json
+++ b/packages/form-validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manufosela/form-validators",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "type": "module",
   "description": "Pure deterministic predicates for common form-field validation: email, URL, phones, Spanish documents (NIF/NIE/CIF), banking (IBAN-style account, credit card), dates, postal codes and more. Zero dependencies, zero DOM access.",
   "main": "src/index.js",

--- a/packages/form-validators/src/aliases.js
+++ b/packages/form-validators/src/aliases.js
@@ -3,29 +3,33 @@
 // canonical names) to the corresponding validator function. Keys are
 // case-insensitive when looked up via `validate()`.
 
-import { integer } from './primitive/integer.js';
-import { float } from './primitive/float.js';
-import { number } from './primitive/number.js';
+import { integer, normalizeInteger } from './primitive/integer.js';
+import { float, normalizeFloat } from './primitive/float.js';
+import { number, normalizeNumber } from './primitive/number.js';
 import {
   alpha,
   alphaWithDash,
   alphanumeric,
   alphanumericWithSpace,
+  normalizeAlpha,
+  normalizeAlphaWithDash,
+  normalizeAlphanumeric,
+  normalizeAlphanumericWithSpace,
 } from './primitive/alpha.js';
-import { date } from './primitive/date.js';
-import { fileExtension } from './file/extension.js';
-import { email } from './comms/email.js';
-import { url } from './comms/url.js';
-import { mobileEs } from './comms/mobileEs.js';
-import { landlineEs } from './comms/landlineEs.js';
-import { telephoneEs } from './comms/telephoneEs.js';
-import { postalCodeEs } from './comms/postalCodeEs.js';
-import { iccid } from './comms/iccid.js';
-import { nif } from './es/nif.js';
-import { nie } from './es/nie.js';
-import { cif } from './es/cif.js';
-import { bankAccountEs } from './es/bankAccountEs.js';
-import { creditCard } from './banking/creditCard.js';
+import { date, normalizeDate } from './primitive/date.js';
+import { fileExtension, normalizeFileExtension } from './file/extension.js';
+import { email, normalizeEmail } from './comms/email.js';
+import { url, normalizeUrl } from './comms/url.js';
+import { mobileEs, normalizeMobileEs } from './comms/mobileEs.js';
+import { landlineEs, normalizeLandlineEs } from './comms/landlineEs.js';
+import { telephoneEs, normalizeTelephoneEs } from './comms/telephoneEs.js';
+import { postalCodeEs, normalizePostalCodeEs } from './comms/postalCodeEs.js';
+import { iccid, normalizeIccid } from './comms/iccid.js';
+import { nif, normalizeNif } from './es/nif.js';
+import { nie, normalizeNie } from './es/nie.js';
+import { cif, normalizeCif } from './es/cif.js';
+import { bankAccountEs, normalizeBankAccountEs } from './es/bankAccountEs.js';
+import { creditCard, normalizeCreditCard } from './banking/creditCard.js';
 
 /**
  * Dispatch table. All keys are lowercase; lookup via {@link validate} is
@@ -100,4 +104,82 @@ export function validate(name) {
   if (typeof name !== 'string') return null;
   const fn = validators[name.toLowerCase()];
   return typeof fn === 'function' ? fn : null;
+}
+
+/**
+ * Normalizers dispatch table. Mirrors {@link validators} key-by-key, so
+ * every alias accepted by `validate(name)` also has a `normalize(name)`.
+ * @type {Readonly<Record<string, (value: unknown, ...rest: any[]) => string>>}
+ */
+export const normalizers = Object.freeze({
+  // Primitive
+  int: normalizeInteger,
+  integer: normalizeInteger,
+  float: normalizeFloat,
+  number: normalizeNumber,
+  numero: normalizeNumber,
+  alpha: normalizeAlpha,
+  alfa: normalizeAlpha,
+  text: normalizeAlpha,
+  texto: normalizeAlpha,
+  'text-': normalizeAlphaWithDash,
+  alphawithdash: normalizeAlphaWithDash,
+  alphanumeric: normalizeAlphanumeric,
+  textnum: normalizeAlphanumeric,
+  alphanumericspace: normalizeAlphanumericWithSpace,
+  alphanumericwithspace: normalizeAlphanumericWithSpace,
+  textspace: normalizeAlphanumericWithSpace,
+  date: normalizeDate,
+  fecha: normalizeDate,
+  // File
+  file: normalizeFileExtension,
+  fileextension: normalizeFileExtension,
+  // Communications
+  email: normalizeEmail,
+  correo: normalizeEmail,
+  url: normalizeUrl,
+  iccid: normalizeIccid,
+  mobile: normalizeMobileEs,
+  movil: normalizeMobileEs,
+  nummovil: normalizeMobileEs,
+  mobilees: normalizeMobileEs,
+  landphone: normalizeLandlineEs,
+  fijo: normalizeLandlineEs,
+  numfijo: normalizeLandlineEs,
+  landlinees: normalizeLandlineEs,
+  tel: normalizeTelephoneEs,
+  telefono: normalizeTelephoneEs,
+  telephone: normalizeTelephoneEs,
+  telephonees: normalizeTelephoneEs,
+  cp: normalizePostalCodeEs,
+  postalcode: normalizePostalCodeEs,
+  postalcodees: normalizePostalCodeEs,
+  // Spanish documents
+  nif: normalizeNif,
+  nie: normalizeNie,
+  cif: normalizeCif,
+  cuentabancaria: normalizeBankAccountEs,
+  accountnumber: normalizeBankAccountEs,
+  bankaccountes: normalizeBankAccountEs,
+  // Banking
+  creditcard: normalizeCreditCard,
+  tarjetacredito: normalizeCreditCard,
+});
+
+/**
+ * Look up a normalizer by name (case-insensitive). When the name is
+ * unknown, returns a fallback that just trims strings (so consumers can
+ * always call `normalize(name)(value)` safely without checking for null).
+ * @example
+ *   const cleanEmail = normalize('email');
+ *   cleanEmail(' Manu@X.IO '); // → 'manu@x.io'
+ * @param {string} name
+ * @returns {(value: unknown, ...rest: any[]) => string}
+ */
+export function normalize(name) {
+  if (typeof name === 'string') {
+    const fn = normalizers[name.toLowerCase()];
+    if (typeof fn === 'function') return fn;
+  }
+  return (value) => (typeof value === 'string' ? value.trim() : String(value ?? ''));
 }

--- a/packages/form-validators/src/banking/creditCard.js
+++ b/packages/form-validators/src/banking/creditCard.js
@@ -1,4 +1,16 @@
 /**
+ * Canonical form: trim and strip every space, hyphen and dot. A 16-digit
+ * card dictated as `4111 1111 1111 1111` or `4111-1111-1111-1111`
+ * becomes `4111111111111111`.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeCreditCard(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s.\-]/g, '');
+}
+
+/**
  * Validate a 16-digit credit card number using the Luhn algorithm. The
  * leading digit must be one of 3 (Amex/Diners), 4 (Visa), 5 (Mastercard)
  * or 6 (Discover) — matching the legacy `verificaNumTarjetaCredito`

--- a/packages/form-validators/src/comms/email.js
+++ b/packages/form-validators/src/comms/email.js
@@ -10,3 +10,14 @@ export function email(value) {
   if (typeof value !== 'string' || value === '') return false;
   return /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,24}$/.test(value);
 }
+
+/**
+ * Canonical form: trim, strip internal whitespace, lowercase the whole
+ * address (the local part is case-insensitive in practice).
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeEmail(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/\s+/g, '').toLowerCase();
+}

--- a/packages/form-validators/src/comms/iccid.js
+++ b/packages/form-validators/src/comms/iccid.js
@@ -1,4 +1,14 @@
 /**
+ * Canonical form: trim and strip every space and hyphen.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeIccid(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '');
+}
+
+/**
  * Validate an ICCID (SIM card identifier): 19 or 20 digits, must start
  * with the telecommunications industry prefix `89`, and the last digit
  * is a Luhn-style check digit using the variant employed by the legacy

--- a/packages/form-validators/src/comms/landlineEs.js
+++ b/packages/form-validators/src/comms/landlineEs.js
@@ -11,3 +11,13 @@ export function landlineEs(value) {
   const cleaned = value.replace(/[\s-]/g, '');
   return /^(?:\+?[0-9]{2}|00[0-9]{2})?[0-9]{9}$/.test(cleaned);
 }
+
+/**
+ * Canonical form: trim, strip space/hyphen and any Spanish country prefix.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeLandlineEs(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '').replace(/^(?:\+34|0034|34)/, '');
+}

--- a/packages/form-validators/src/comms/mobileEs.js
+++ b/packages/form-validators/src/comms/mobileEs.js
@@ -10,3 +10,14 @@ export function mobileEs(value) {
   const cleaned = value.replace(/[\s-]/g, '');
   return /^(?:\+?[0-9]{2}|00[0-9]{2})?(?:6|7)[0-9]{8}$/.test(cleaned);
 }
+
+/**
+ * Canonical form: trim, strip every space/hyphen and any Spanish country
+ * prefix (`+34`, `0034`, `34`). Returns just the 9 local digits.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeMobileEs(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '').replace(/^(?:\+34|0034|34)/, '');
+}

--- a/packages/form-validators/src/comms/postalCodeEs.js
+++ b/packages/form-validators/src/comms/postalCodeEs.js
@@ -10,3 +10,13 @@ export function postalCodeEs(value) {
   if (typeof value !== 'string') return false;
   return /^\d{5}$/.test(value);
 }
+
+/**
+ * Canonical form: trim only — leading zeros are significant.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizePostalCodeEs(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim();
+}

--- a/packages/form-validators/src/comms/telephoneEs.js
+++ b/packages/form-validators/src/comms/telephoneEs.js
@@ -1,4 +1,4 @@
-import { mobileEs } from './mobileEs.js';
+import { mobileEs, normalizeMobileEs } from './mobileEs.js';
 import { landlineEs } from './landlineEs.js';
 
 /**
@@ -8,4 +8,14 @@ import { landlineEs } from './landlineEs.js';
  */
 export function telephoneEs(value) {
   return mobileEs(value) || landlineEs(value);
+}
+
+/**
+ * Canonical form: same rules as mobile / landline normalize (they share
+ * the strip-prefix-and-separators logic).
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeTelephoneEs(value) {
+  return normalizeMobileEs(value);
 }

--- a/packages/form-validators/src/comms/url.js
+++ b/packages/form-validators/src/comms/url.js
@@ -10,3 +10,20 @@ export function url(value) {
     value,
   );
 }
+
+/**
+ * Canonical form: trim and prepend `https://` when the user-typed value
+ * starts directly with a domain. Lowercases the scheme + host. Path,
+ * query and fragment are kept as-is.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeUrl(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  let v = value.trim();
+  if (!/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(v)) v = `https://${v}`;
+  // Lowercase scheme + host but preserve path/query/fragment casing.
+  const m = v.match(/^([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)([^/?#]+)(.*)$/);
+  if (!m) return v;
+  return `${m[1].toLowerCase()}${m[2].toLowerCase()}${m[3]}`;
+}

--- a/packages/form-validators/src/es/bankAccountEs.js
+++ b/packages/form-validators/src/es/bankAccountEs.js
@@ -1,4 +1,15 @@
 /**
+ * Canonical form: trim and strip every space and hyphen so a CCC dictated
+ * with separators (`2100 0418 4502 0000 5678`) becomes a 20-digit string.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeBankAccountEs(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '');
+}
+
+/**
  * Validate a Spanish bank account number in the legacy CCC format
  * (20 digits: 4 bank + 4 branch + 2 control + 10 account). The two control
  * digits are computed from the bank+branch and account parts respectively

--- a/packages/form-validators/src/es/cif.js
+++ b/packages/form-validators/src/es/cif.js
@@ -1,6 +1,16 @@
 import { cifControlChars } from './_dni-letter.js';
 
 /**
+ * Canonical form: trim, uppercase, strip internal whitespace and hyphens.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeCif(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '').toUpperCase();
+}
+
+/**
  * Validate a Spanish CIF (Código de Identificación Fiscal). Format: an
  * entity letter (A-H, J, N, P, Q, R, S, U, V, W) + 7 digits + control
  * character which is either a digit or a letter depending on the entity

--- a/packages/form-validators/src/es/nie.js
+++ b/packages/form-validators/src/es/nie.js
@@ -1,6 +1,16 @@
 import { dniLetterFor } from './_dni-letter.js';
 
 /**
+ * Canonical form: trim, uppercase, strip internal whitespace and hyphens.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeNie(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '').toUpperCase();
+}
+
+/**
  * Validate a Spanish NIE (Número de Identidad de Extranjero). Two formats:
  * - Modern: starts with X, Y or Z + 7 digits + control letter. The leading
  *   letter maps to a digit (X→0, Y→1, Z→2), and the resulting 8-digit

--- a/packages/form-validators/src/es/nif.js
+++ b/packages/form-validators/src/es/nif.js
@@ -1,6 +1,16 @@
 import { dniLetterFor, cifControlChars } from './_dni-letter.js';
 
 /**
+ * Canonical form: trim, uppercase, strip internal whitespace and hyphens.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeNif(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/[\s-]/g, '').toUpperCase();
+}
+
+/**
  * Validate a Spanish NIF (Número de Identificación Fiscal). Covers:
  * - Standard NIF: 8 digits + control letter from the official table.
  * - Special NIF (KLM): starts with K, L or M; the control character is

--- a/packages/form-validators/src/file/extension.js
+++ b/packages/form-validators/src/file/extension.js
@@ -10,3 +10,14 @@ export function fileExtension(filename, validExtensions) {
   if (!Array.isArray(validExtensions) || validExtensions.length === 0) return false;
   return validExtensions.some((ext) => typeof ext === 'string' && filename.endsWith(ext));
 }
+
+/**
+ * Canonical form: just trim. Filenames are case-sensitive on most systems
+ * so we don't lower/uppercase here.
+ * @param {unknown} filename
+ * @returns {string}
+ */
+export function normalizeFileExtension(filename) {
+  if (typeof filename !== 'string') return String(filename ?? '');
+  return filename.trim();
+}

--- a/packages/form-validators/src/index.js
+++ b/packages/form-validators/src/index.js
@@ -4,37 +4,41 @@
 // touch the DOM.
 
 // Primitive
-export { integer } from './primitive/integer.js';
-export { float } from './primitive/float.js';
-export { number } from './primitive/number.js';
+export { integer, normalizeInteger } from './primitive/integer.js';
+export { float, normalizeFloat } from './primitive/float.js';
+export { number, normalizeNumber } from './primitive/number.js';
 export {
   alpha,
   alphaWithDash,
   alphanumeric,
   alphanumericWithSpace,
+  normalizeAlpha,
+  normalizeAlphaWithDash,
+  normalizeAlphanumeric,
+  normalizeAlphanumericWithSpace,
 } from './primitive/alpha.js';
-export { date } from './primitive/date.js';
+export { date, normalizeDate } from './primitive/date.js';
 
 // File
-export { fileExtension } from './file/extension.js';
+export { fileExtension, normalizeFileExtension } from './file/extension.js';
 
 // Communications
-export { email } from './comms/email.js';
-export { url } from './comms/url.js';
-export { mobileEs } from './comms/mobileEs.js';
-export { landlineEs } from './comms/landlineEs.js';
-export { telephoneEs } from './comms/telephoneEs.js';
-export { postalCodeEs } from './comms/postalCodeEs.js';
-export { iccid } from './comms/iccid.js';
+export { email, normalizeEmail } from './comms/email.js';
+export { url, normalizeUrl } from './comms/url.js';
+export { mobileEs, normalizeMobileEs } from './comms/mobileEs.js';
+export { landlineEs, normalizeLandlineEs } from './comms/landlineEs.js';
+export { telephoneEs, normalizeTelephoneEs } from './comms/telephoneEs.js';
+export { postalCodeEs, normalizePostalCodeEs } from './comms/postalCodeEs.js';
+export { iccid, normalizeIccid } from './comms/iccid.js';
 
 // Spanish documents
-export { nif } from './es/nif.js';
-export { nie } from './es/nie.js';
-export { cif } from './es/cif.js';
-export { bankAccountEs } from './es/bankAccountEs.js';
+export { nif, normalizeNif } from './es/nif.js';
+export { nie, normalizeNie } from './es/nie.js';
+export { cif, normalizeCif } from './es/cif.js';
+export { bankAccountEs, normalizeBankAccountEs } from './es/bankAccountEs.js';
 
 // Banking
-export { creditCard } from './banking/creditCard.js';
+export { creditCard, normalizeCreditCard } from './banking/creditCard.js';
 
 // Dispatch by name (with all the legacy aliases).
-export { validate, validators } from './aliases.js';
+export { validate, validators, normalize, normalizers } from './aliases.js';

--- a/packages/form-validators/src/primitive/alpha.js
+++ b/packages/form-validators/src/primitive/alpha.js
@@ -42,3 +42,19 @@ export function alphanumericWithSpace(value) {
   if (typeof value !== 'string' || value === '') return false;
   return new RegExp(`^[0-9${LETTERS}\\s]+$`).test(value);
 }
+
+/**
+ * Canonical form for alpha-family inputs: trim + collapse internal runs of
+ * whitespace into a single space (handles dictation pauses like "Manu  Fosela").
+ * @param {unknown} value
+ * @returns {string}
+ */
+function normalizeAlphaLike(value) {
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export const normalizeAlpha = normalizeAlphaLike;
+export const normalizeAlphaWithDash = normalizeAlphaLike;
+export const normalizeAlphanumeric = (v) => (typeof v === 'string' ? v.trim() : String(v ?? ''));
+export const normalizeAlphanumericWithSpace = normalizeAlphaLike;

--- a/packages/form-validators/src/primitive/date.js
+++ b/packages/form-validators/src/primitive/date.js
@@ -1,4 +1,24 @@
 /**
+ * Canonical form: trim and pad day/month with leading zero. Picks `/` as
+ * separator. The mode (`dmy` / `mdy` / `ymd`) is used to know which of the
+ * three numeric segments is which.
+ * @param {unknown} value
+ * @param {'dmy' | 'mdy' | 'ymd'} [mode] Default `'dmy'`.
+ * @returns {string}
+ */
+export function normalizeDate(value, mode = 'dmy') {
+  if (typeof value !== 'string') return String(value ?? '');
+  const trimmed = value.trim();
+  const m = trimmed.match(/^(\d{1,4})(?:\/|-)(\d{1,2})(?:\/|-)(\d{1,4})$/);
+  if (!m) return trimmed;
+  const [, a, b, c] = m;
+  const pad = (s, n = 2) => s.padStart(n, '0');
+  if (mode === 'mdy') return `${pad(a)}/${pad(b)}/${pad(c, 4)}`;
+  if (mode === 'ymd') return `${pad(a, 4)}/${pad(b)}/${pad(c)}`;
+  return `${pad(a)}/${pad(b)}/${pad(c, 4)}`;
+}
+
+/**
  * Validate a calendar date in `dd/mm/yyyy`, `mm/dd/yyyy` or `yyyy-mm-dd`
  * format (configurable via `mode`). Checks month range, day range, days
  * per month and leap years. Separators may be `/` or `-`.

--- a/packages/form-validators/src/primitive/float.js
+++ b/packages/form-validators/src/primitive/float.js
@@ -12,3 +12,14 @@ export function float(value) {
   // Reject things like "3.14abc" that parseFloat is otherwise lenient about.
   return /^-?\d+(?:\.\d+)?$/.test(value.trim());
 }
+
+/**
+ * Canonical form: trim and accept comma as decimal separator (',' → '.').
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeFloat(value) {
+  if (typeof value === 'number') return String(value);
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(',', '.');
+}

--- a/packages/form-validators/src/primitive/integer.js
+++ b/packages/form-validators/src/primitive/integer.js
@@ -11,3 +11,16 @@ export function integer(value) {
   if (Number.isNaN(parsed)) return false;
   return String(parsed) === value.trim();
 }
+
+/**
+ * Canonical form: trim and convert to a digit-only string. Returns the
+ * input untouched when it can't be cleanly normalized so the predicate
+ * can still report it as invalid.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeInteger(value) {
+  if (typeof value === 'number') return Number.isInteger(value) ? String(value) : String(value);
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim();
+}

--- a/packages/form-validators/src/primitive/number.js
+++ b/packages/form-validators/src/primitive/number.js
@@ -9,3 +9,14 @@ export function number(value) {
   if (typeof value !== 'string' && typeof value !== 'number') return false;
   return /^[0-9.]+$/.test(String(value));
 }
+
+/**
+ * Canonical form: trim and accept comma as decimal separator.
+ * @param {unknown} value
+ * @returns {string}
+ */
+export function normalizeNumber(value) {
+  if (typeof value === 'number') return String(value);
+  if (typeof value !== 'string') return String(value ?? '');
+  return value.trim().replace(',', '.');
+}

--- a/packages/form-validators/test/normalize.test.js
+++ b/packages/form-validators/test/normalize.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeInteger,
+  normalizeFloat,
+  normalizeNumber,
+  normalizeAlpha,
+  normalizeAlphaWithDash,
+  normalizeAlphanumeric,
+  normalizeAlphanumericWithSpace,
+  normalizeDate,
+  normalizeFileExtension,
+  normalizeEmail,
+  normalizeUrl,
+  normalizeMobileEs,
+  normalizeLandlineEs,
+  normalizeTelephoneEs,
+  normalizePostalCodeEs,
+  normalizeIccid,
+  normalizeNif,
+  normalizeNie,
+  normalizeCif,
+  normalizeBankAccountEs,
+  normalizeCreditCard,
+  normalize,
+  normalizers,
+} from '../src/index.js';
+
+describe('normalizeInteger / Float / Number', () => {
+  it('trims', () => {
+    expect(normalizeInteger(' 42 ')).toBe('42');
+    expect(normalizeFloat(' 3.14 ')).toBe('3.14');
+    expect(normalizeNumber(' 1.5 ')).toBe('1.5');
+  });
+  it('accepts comma as decimal separator (float / number)', () => {
+    expect(normalizeFloat('3,14')).toBe('3.14');
+    expect(normalizeNumber('3,14')).toBe('3.14');
+  });
+  it('coerces non-strings to strings', () => {
+    expect(normalizeInteger(42)).toBe('42');
+    expect(normalizeFloat(3.14)).toBe('3.14');
+    expect(normalizeInteger(null)).toBe('');
+  });
+});
+
+describe('alpha-family normalizers', () => {
+  it('trims and collapses internal whitespace runs', () => {
+    expect(normalizeAlpha('  Manu   Fosela  ')).toBe('Manu Fosela');
+    expect(normalizeAlphaWithDash('  Pérez   -   Galdós  ')).toBe('Pérez - Galdós');
+    expect(normalizeAlphanumericWithSpace('  abc   123  ')).toBe('abc 123');
+  });
+  it('alphanumeric (no space) only trims', () => {
+    expect(normalizeAlphanumeric('  abc123  ')).toBe('abc123');
+  });
+});
+
+describe('normalizeDate', () => {
+  it('trims, pads single-digit segments and uses /', () => {
+    expect(normalizeDate(' 5-3-2026 ')).toBe('05/03/2026');
+    expect(normalizeDate('15-03-2026')).toBe('15/03/2026');
+  });
+  it('respects mode for ymd', () => {
+    expect(normalizeDate('2026-3-5', 'ymd')).toBe('2026/03/05');
+  });
+  it('passes through if not a recognised shape', () => {
+    expect(normalizeDate('not a date')).toBe('not a date');
+  });
+});
+
+describe('file / postal / iccid', () => {
+  it('normalizeFileExtension only trims', () => {
+    expect(normalizeFileExtension(' cv.pdf ')).toBe('cv.pdf');
+  });
+  it('normalizePostalCodeEs preserves leading zeros', () => {
+    expect(normalizePostalCodeEs(' 08001 ')).toBe('08001');
+  });
+  it('normalizeIccid strips spaces and hyphens', () => {
+    expect(normalizeIccid(' 8934-0751-0012-3456-789 ')).toBe('89340751001234567' + '89');
+  });
+});
+
+describe('normalizeEmail', () => {
+  it('trims, strips internal whitespace and lowercases', () => {
+    expect(normalizeEmail(' Manu@Example.IO ')).toBe('manu@example.io');
+    expect(normalizeEmail('m a n u @ x . io')).toBe('manu@x.io');
+  });
+});
+
+describe('normalizeUrl', () => {
+  it('prepends https:// when scheme is missing', () => {
+    expect(normalizeUrl(' example.com ')).toBe('https://example.com');
+  });
+  it('lowercases scheme + host but preserves path/query casing', () => {
+    expect(normalizeUrl('HTTPS://Example.COM/MyPath?Q=1')).toBe('https://example.com/MyPath?Q=1');
+  });
+  it('keeps existing http://', () => {
+    expect(normalizeUrl('http://example.org')).toBe('http://example.org');
+  });
+});
+
+describe('normalizeMobileEs / LandlineEs / TelephoneEs', () => {
+  it('strips spaces, hyphens and Spanish country prefix (+34, 0034, 34)', () => {
+    expect(normalizeMobileEs('+34 639 01 89 87')).toBe('639018987');
+    expect(normalizeMobileEs('0034-639-018-987')).toBe('639018987');
+    expect(normalizeMobileEs('34 639 01 89 87')).toBe('639018987');
+    expect(normalizeMobileEs('639018987')).toBe('639018987');
+  });
+  it('landline + telephone use the same rules', () => {
+    expect(normalizeLandlineEs('+34 912 34 56 78')).toBe('912345678');
+    expect(normalizeTelephoneEs('+34 639 01 89 87')).toBe('639018987');
+  });
+});
+
+describe('Spanish documents', () => {
+  it('normalizeNif / Nie / Cif: trim, uppercase, strip separators', () => {
+    expect(normalizeNif(' 12345678z ')).toBe('12345678Z');
+    expect(normalizeNif('12-345-678-z')).toBe('12345678Z');
+    expect(normalizeNie(' x1234567l ')).toBe('X1234567L');
+    expect(normalizeCif(' a58818501 ')).toBe('A58818501');
+  });
+  it('normalizeBankAccountEs strips separators', () => {
+    expect(normalizeBankAccountEs(' 2100 0418 4502 0000 5678 ')).toBe(
+      '21000418450200005678',
+    );
+  });
+});
+
+describe('normalizeCreditCard', () => {
+  it('strips spaces, hyphens and dots', () => {
+    expect(normalizeCreditCard('4111-1111-1111-1111')).toBe('4111111111111111');
+    expect(normalizeCreditCard('4111 1111 1111 1111')).toBe('4111111111111111');
+    expect(normalizeCreditCard('4111.1111.1111.1111')).toBe('4111111111111111');
+  });
+});
+
+describe('normalize(name) dispatcher', () => {
+  it('returns the right function for every alias', () => {
+    expect(normalize('email')(' A@b.IO ')).toBe('a@b.io');
+    expect(normalize('correo')(' A@b.IO ')).toBe('a@b.io');
+    expect(normalize('movil')(' +34 639 01 89 87 ')).toBe('639018987');
+    expect(normalize('mobile')(' +34 639 01 89 87 ')).toBe('639018987');
+    expect(normalize('NIF')(' 12345678z ')).toBe('12345678Z');
+    expect(normalize('cuentabancaria')(' 2100 0418 4502 0000 5678 ')).toBe(
+      '21000418450200005678',
+    );
+  });
+  it('falls back to a trim normalizer for unknown names', () => {
+    expect(normalize('thisDoesNotExist')(' hello ')).toBe('hello');
+    expect(normalize(/** @type {any} */ (null))(' hello ')).toBe('hello');
+  });
+  it('exposes normalizers dispatch table as a frozen object', () => {
+    expect(Object.isFrozen(normalizers)).toBe(true);
+    expect(Object.keys(normalizers).length).toBeGreaterThan(20);
+  });
+});
+
+describe('normalize → validate composition', () => {
+  it('messy input becomes valid after normalize', async () => {
+    const { mobileEs, email, nif } = await import('../src/index.js');
+    expect(mobileEs(normalizeMobileEs('+34 639 01 89 87'))).toBe(true);
+    expect(email(normalizeEmail(' Manu@X.IO '))).toBe(true);
+    expect(nif(normalizeNif(' 12345678z '))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a `normalize<Name>(value)` function alongside every validator, plus a `normalize(name)` dispatcher mirroring `validate(name)`. Lets consumers go from messy raw input to canonical form deterministically before calling the predicate.

```js
import { normalizeMobileEs, mobileEs } from '@manufosela/form-validators';
const value = normalizeMobileEs('+34 639 01 89 87'); // '639018987'
mobileEs(value); // true
```

### Canonical forms

| Input | Output |
| ----- | ------ |
| `'+34 639 01 89 87'` (mobileEs) | `'639018987'` |
| `' Manu@Example.IO '` (email) | `'manu@example.io'` |
| `' 12345678z '` (nif) | `'12345678Z'` |
| `'2100 0418 4502 0000 5678'` (bankAccountEs) | `'21000418450200005678'` |
| `'example.com'` (url) | `'https://example.com'` |
| `'5-3-2026'` (date dmy) | `'05/03/2026'` |
| `'4111-1111-1111-1111'` (creditCard) | `'4111111111111111'` |

### Version policy

**Bump 0.1.0 → 1.0.0.** Project policy from now on: semver from 1.0.0, no 0.x phase. Documented in the README's new "Versioning" section.

`automatic_form_validation` keeps its current `1.7.0` (no API change).

## Test plan
- [x] `pnpm test` — 81 in form-validators (24 new normalizer tests), 63 in automatic-form-validation. **144 total.**
- [ ] After merge: `pnpm publish` for `@manufosela/form-validators@1.0.0` (you'll handle OTP).

Closes **AFV-TSK-0007**.